### PR TITLE
[Update] Key 버리고 Building Script넣어서 관리하도록함 개쩜

### DIFF
--- a/Assets/Resources/Prefabs/Buildings/BlueTeamBuildings/Barrack.prefab
+++ b/Assets/Resources/Prefabs/Buildings/BlueTeamBuildings/Barrack.prefab
@@ -66,6 +66,15 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 100000, guid: 7036859d28e2cb84c9948a1fcf49fe95, type: 3}
       insertIndex: -1
       addedObject: {fileID: 8515307855472878936}
+    - targetCorrespondingSourceObject: {fileID: 100000, guid: 7036859d28e2cb84c9948a1fcf49fe95, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: -8199964646472358792}
+    - targetCorrespondingSourceObject: {fileID: 100000, guid: 7036859d28e2cb84c9948a1fcf49fe95, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 4563233554073095194}
+    - targetCorrespondingSourceObject: {fileID: 100000, guid: 7036859d28e2cb84c9948a1fcf49fe95, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: -910109380999945870}
   m_SourcePrefab: {fileID: 100100000, guid: 7036859d28e2cb84c9948a1fcf49fe95, type: 3}
 --- !u!1 &1856497004635135170 stripped
 GameObject:
@@ -120,3 +129,54 @@ MonoBehaviour:
   mouseHoverEvent:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &-8199964646472358792
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1856497004635135170}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ObservedComponentsFoldoutOpen: 1
+  Group: 0
+  prefixField: -1
+  Synchronization: 3
+  OwnershipTransfer: 0
+  observableSearch: 2
+  ObservedComponents:
+  - {fileID: -910109380999945870}
+  sceneViewId: 0
+  InstantiationId: 0
+  isRuntimeInstantiated: 0
+--- !u!114 &4563233554073095194
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1856497004635135170}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09ab038f4b0b74df68f4e151012abaf5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &-910109380999945870
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1856497004635135170}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 627855c7f81362d41938ffe0b1475957, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SynchronizePosition: 1
+  m_SynchronizeRotation: 1
+  m_SynchronizeScale: 0
+  m_UseLocal: 1

--- a/Assets/Resources/Prefabs/Buildings/BlueTeamBuildings/Command.prefab
+++ b/Assets/Resources/Prefabs/Buildings/BlueTeamBuildings/Command.prefab
@@ -59,6 +59,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 100000, guid: 637b3bb1a53fd584b8b2f29eddb05290, type: 3}
       insertIndex: -1
       addedObject: {fileID: -2298696398026779216}
+    - targetCorrespondingSourceObject: {fileID: 100000, guid: 637b3bb1a53fd584b8b2f29eddb05290, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: -5617368362746634423}
   m_SourcePrefab: {fileID: 100100000, guid: 637b3bb1a53fd584b8b2f29eddb05290, type: 3}
 --- !u!1 &5353990028829860153 stripped
 GameObject:
@@ -86,3 +89,25 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 6.736253, y: 6.657968, z: 4.695601}
   m_Center: {x: 0.072093606, y: -0.03884519, z: 1.6146704}
+--- !u!114 &-5617368362746634423
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5353990028829860153}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ObservedComponentsFoldoutOpen: 1
+  Group: 0
+  prefixField: -1
+  Synchronization: 3
+  OwnershipTransfer: 0
+  observableSearch: 2
+  ObservedComponents: []
+  sceneViewId: 0
+  InstantiationId: 0
+  isRuntimeInstantiated: 0

--- a/Assets/Resources/Prefabs/Buildings/BlueTeamBuildings/Defender.prefab
+++ b/Assets/Resources/Prefabs/Buildings/BlueTeamBuildings/Defender.prefab
@@ -59,6 +59,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 100000, guid: f38b9a56b23e4df499eaede1c2276296, type: 3}
       insertIndex: -1
       addedObject: {fileID: 8499897816083107414}
+    - targetCorrespondingSourceObject: {fileID: 100000, guid: f38b9a56b23e4df499eaede1c2276296, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: -6744043205098766824}
   m_SourcePrefab: {fileID: 100100000, guid: f38b9a56b23e4df499eaede1c2276296, type: 3}
 --- !u!1 &1631118528069862760 stripped
 GameObject:
@@ -86,3 +89,25 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 6.736253, y: 6.657968, z: 4.695601}
   m_Center: {x: 0.072093606, y: -0.03884519, z: 1.6146704}
+--- !u!114 &-6744043205098766824
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1631118528069862760}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ObservedComponentsFoldoutOpen: 1
+  Group: 0
+  prefixField: -1
+  Synchronization: 3
+  OwnershipTransfer: 0
+  observableSearch: 2
+  ObservedComponents: []
+  sceneViewId: 0
+  InstantiationId: 0
+  isRuntimeInstantiated: 0

--- a/Assets/Resources/Prefabs/Buildings/BlueTeamBuildings/PopulationBuilding.prefab
+++ b/Assets/Resources/Prefabs/Buildings/BlueTeamBuildings/PopulationBuilding.prefab
@@ -59,6 +59,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 100000, guid: 05035b78d90b21f43854dfe010ccd289, type: 3}
       insertIndex: -1
       addedObject: {fileID: -6800102935426118997}
+    - targetCorrespondingSourceObject: {fileID: 100000, guid: 05035b78d90b21f43854dfe010ccd289, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: -24312675276253883}
   m_SourcePrefab: {fileID: 100100000, guid: 05035b78d90b21f43854dfe010ccd289, type: 3}
 --- !u!1 &3850242999582102491 stripped
 GameObject:
@@ -86,3 +89,25 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 6.736253, y: 6.657968, z: 4.695601}
   m_Center: {x: 0.072093606, y: -0.03884519, z: 1.6146704}
+--- !u!114 &-24312675276253883
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3850242999582102491}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ObservedComponentsFoldoutOpen: 1
+  Group: 0
+  prefixField: -1
+  Synchronization: 3
+  OwnershipTransfer: 0
+  observableSearch: 2
+  ObservedComponents: []
+  sceneViewId: 0
+  InstantiationId: 0
+  isRuntimeInstantiated: 0

--- a/Assets/Resources/Prefabs/Buildings/BlueTeamBuildings/ResourceBuilding.prefab
+++ b/Assets/Resources/Prefabs/Buildings/BlueTeamBuildings/ResourceBuilding.prefab
@@ -59,6 +59,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 100000, guid: 520e20395d1150a4c94174228bde0499, type: 3}
       insertIndex: -1
       addedObject: {fileID: 5282281350536615715}
+    - targetCorrespondingSourceObject: {fileID: 100000, guid: 520e20395d1150a4c94174228bde0499, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: -1079326836089105715}
   m_SourcePrefab: {fileID: 100100000, guid: 520e20395d1150a4c94174228bde0499, type: 3}
 --- !u!1 &7725685943264554975 stripped
 GameObject:
@@ -86,3 +89,25 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 6.736253, y: 6.657968, z: 4.695601}
   m_Center: {x: 0.072093606, y: -0.03884519, z: 1.6146704}
+--- !u!114 &-1079326836089105715
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7725685943264554975}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ObservedComponentsFoldoutOpen: 1
+  Group: 0
+  prefixField: -1
+  Synchronization: 3
+  OwnershipTransfer: 0
+  observableSearch: 2
+  ObservedComponents: []
+  sceneViewId: 0
+  InstantiationId: 0
+  isRuntimeInstantiated: 0

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -4676,6 +4676,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 027425fee9066e44aa0ea41804b4fa83, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  unitInfo: 
   UILists:
   - {fileID: 1346158155}
   - {fileID: 648798559}
@@ -6771,6 +6772,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1207655761}
     m_Modifications:
+    - target: {fileID: -8199964646472358792, guid: 623c6587162144caeb68cfefa087a8b5, type: 3}
+      propertyPath: sceneViewId
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 1856497004635135170, guid: 623c6587162144caeb68cfefa087a8b5, type: 3}
       propertyPath: m_Name
       value: Barrack
@@ -9374,6 +9379,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1207655761}
     m_Modifications:
+    - target: {fileID: -1079326836089105715, guid: 21c96d2102cea476a9a7edaec5c5ddf0, type: 3}
+      propertyPath: sceneViewId
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 7725685943264554975, guid: 21c96d2102cea476a9a7edaec5c5ddf0, type: 3}
       propertyPath: m_Name
       value: ResourceBuilding
@@ -12732,6 +12741,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1207655761}
     m_Modifications:
+    - target: {fileID: -24312675276253883, guid: 9ba17f39d27a84e578312c4d6585e9aa, type: 3}
+      propertyPath: sceneViewId
+      value: 4
+      objectReference: {fileID: 0}
     - target: {fileID: 3850242999581741051, guid: 9ba17f39d27a84e578312c4d6585e9aa, type: 3}
       propertyPath: m_LocalPosition.x
       value: -3.6445746
@@ -14655,6 +14668,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1207655761}
     m_Modifications:
+    - target: {fileID: -6744043205098766824, guid: 13283f29131a14b98893772829b6e5e9, type: 3}
+      propertyPath: sceneViewId
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 1631118528069862760, guid: 13283f29131a14b98893772829b6e5e9, type: 3}
       propertyPath: m_Name
       value: Defender
@@ -18150,6 +18167,8 @@ MonoBehaviour:
   gameStates: []
   uIController: {fileID: 388116729}
   unitController: {fileID: 0}
+  selectedObject: {fileID: 0}
+  unitType: 
   buildingController: {fileID: 2039133045}
   buildingType: 
   grid: {fileID: 2106082650}
@@ -18925,6 +18944,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1207655761}
     m_Modifications:
+    - target: {fileID: -5617368362746634423, guid: 91fb5e91d49b449cfb27c47deb9d4c11, type: 3}
+      propertyPath: sceneViewId
+      value: 5
+      objectReference: {fileID: 0}
     - target: {fileID: -2298696398026779216, guid: 91fb5e91d49b449cfb27c47deb9d4c11, type: 3}
       propertyPath: m_Size.x
       value: 8.197476

--- a/Assets/Scripts/Building/Building.cs
+++ b/Assets/Scripts/Building/Building.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public abstract class Building
+public abstract class Building : MonoBehaviour
 {
 
     public string teamID { get; set; }

--- a/Assets/Scripts/Building/BuildingController.cs
+++ b/Assets/Scripts/Building/BuildingController.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using Photon.Pun;
+using TMPro.EditorUtilities;
 using UnityEngine;
 using UnityEngine.UIElements;
 
@@ -34,9 +36,8 @@ public class BuildingController : MonoBehaviour
     public void CreateBuilding(Vector3 buildingLocation, string buildingType)
     // 건물 생성
     {
-        buildingObject = Instantiate(_buildingPrefabs[buildingType],buildingLocation, Quaternion.Euler(new Vector3(-90, 90, 0)));
-        buildingObject.AddComponent<BuildingID>().SetKey(_buildingID);
-        buildingObject.name = "buildingType" + _buildingID;
+        buildingObject = PhotonNetwork.Instantiate($"Prefabs/Buildings/{_teamID}TeamBuildings/{buildingType}",buildingLocation, Quaternion.Euler(new Vector3(-90, 90, 0)));
+        buildingObject.name = buildingType + _buildingID.ToString();
         GameObject gameObject = buildingObject;
         switch(buildingType)
         {
@@ -48,7 +49,11 @@ public class BuildingController : MonoBehaviour
             case "Barrack":
                 buildingObject.GetComponent<ClickEventHandler>().leftClickDownEvent.AddListener((Vector3 pos) => GameManager.instance.SetClickedObject(gameObject));
                 buildingObject.GetComponent<ClickEventHandler>().leftClickDownEvent.AddListener((Vector3 pos) => GameManager.instance.ChangeUI(1));
-                Barrack _newBarrack = new Barrack(_teamID, 0, buildingLocation);
+
+                // Barrack _newBarrack = new Barrack(_teamID, 0, buildingLocation);
+                Barrack _newBarrack = buildingObject.AddComponent<Barrack>();
+                _newBarrack.Init(_teamID, _buildingID, buildingLocation);
+                
                 buildingList.Add(_buildingID, _newBarrack);
                 break;
             case "PopulationBuilding":
@@ -90,7 +95,7 @@ public class BuildingController : MonoBehaviour
     
     public void UpgradeBuilding()
     {
-        Building building = buildingList[GameManager.instance.clickedObject.GetComponent<BuildingID>().GetKey()];
+        Building building = GameManager.instance.selectedObject.GetComponent<Building>();
         building.buildingLevel++;
     }
 }

--- a/Assets/Scripts/Building/Buildings/Barrack.cs
+++ b/Assets/Scripts/Building/Buildings/Barrack.cs
@@ -15,4 +15,15 @@ public class Barrack : Building
         buildingLevel : 1
         )
     {}
+
+    public void Init(string teamID, int buildingID, Vector3 buildingLocation)
+    {
+        this.teamID = teamID;
+        this.buildingID = buildingID;
+        this.buildingType = "Barrack";
+        this.buildingLocation = buildingLocation;
+        this.buildingHealth = 500;
+        this.buildingLevel = 1;
+        this.buildingCost = 50;
+    }
 }

--- a/Assets/Scripts/UI/UIController.cs
+++ b/Assets/Scripts/UI/UIController.cs
@@ -30,8 +30,7 @@ public class UIController : MonoBehaviour
         // ---------------------- 준현 --------------------
         if(UIindex == 1)
         {
-            int key = clickedObject.GetComponent<BuildingID>().GetKey();
-            Building selectedBarrack = buildingController.buildingList[key];
+            Building selectedBarrack = clickedObject.GetComponent<Barrack>();
             _level = selectedUI.transform.Find("LeftSide/LeftSide/LevelArea/Level").GetComponent<TMP_Text>();
             _level.text = selectedBarrack.buildingLevel.ToString();
         } else if(UIindex == 2)
@@ -54,7 +53,7 @@ public class UIController : MonoBehaviour
 
     public void UpdateLevel(UIContainer currentUI, GameObject clickedObject)
     {
-        int level = buildingController.buildingList[clickedObject.GetComponent<BuildingID>().GetKey()].buildingLevel;
+        int level = clickedObject.GetComponent<Building>().buildingLevel;
         SetLevel(currentUI, level);
     }
     


### PR DESCRIPTION
Building에 MonoBehavior을 상속시켜서 Inspector창에다가 넣을 수 있게 됐다 그래서 Key값을 저장하는 스크립트를 안쓰고도 잘 작동이 되도록 했다.
뿌듯했다.