### PR TITLE
Jun hyun

### DIFF
--- a/Assets/Materials/Background/BuildingArea.mat
+++ b/Assets/Materials/Background/BuildingArea.mat
@@ -1,0 +1,85 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: BuildingArea
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords:
+  - _ALPHAPREMULTIPLY_ON
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: 3000
+  stringTagMap:
+    RenderType: Transparent
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 10
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 3
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 0
+    m_Colors:
+    - _Color: {r: 0.27450976, g: 0.27450976, b: 0.27450976, a: 0.3529412}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Materials/Background/BuildingArea.mat.meta
+++ b/Assets/Materials/Background/BuildingArea.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c22e4993a5fd94f4aa11503d214fc627
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Materials/Background/DefaultGrid.mat
+++ b/Assets/Materials/Background/DefaultGrid.mat
@@ -75,7 +75,7 @@ Material:
     - _DstBlend: 10
     - _EnableExternalAlpha: 0
     - _GlossMapScale: 1
-    - _Glossiness: 0.5
+    - _Glossiness: 0
     - _GlossyReflections: 1
     - _Metallic: 0
     - _Mode: 3
@@ -93,7 +93,7 @@ Material:
     - _UseUIAlphaClip: 0
     - _ZWrite: 0
     m_Colors:
-    - _Color: {r: 1, g: 1, b: 1, a: 0.105882354}
+    - _Color: {r: 1, g: 1, b: 1, a: 0}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _Flip: {r: 1, g: 1, b: 1, a: 1}
     - _RendererColor: {r: 1, g: 1, b: 1, a: 1}

--- a/Assets/Materials/Background/SelectedGrid.mat
+++ b/Assets/Materials/Background/SelectedGrid.mat
@@ -11,13 +11,15 @@ Material:
   m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
+  m_ValidKeywords:
+  - _ALPHAPREMULTIPLY_ON
   m_InvalidKeywords: []
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
+  m_CustomRenderQueue: 3000
+  stringTagMap:
+    RenderType: Transparent
   disabledShaderPasses: []
   m_LockedProperties: 
   m_SavedProperties:
@@ -69,22 +71,22 @@ Material:
     - _BumpScale: 1
     - _Cutoff: 0.5
     - _DetailNormalMapScale: 1
-    - _DstBlend: 0
+    - _DstBlend: 10
     - _EnableExternalAlpha: 0
     - _GlossMapScale: 1
     - _Glossiness: 0.5
     - _GlossyReflections: 1
     - _Metallic: 0
-    - _Mode: 0
+    - _Mode: 3
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1
     - _UVSec: 0
-    - _ZWrite: 1
+    - _ZWrite: 0
     m_Colors:
-    - _Color: {r: 0.2735849, g: 0.2735849, b: 0.2735849, a: 0.79607844}
+    - _Color: {r: 0.4229263, g: 0.9056604, b: 0.45660543, a: 0.39215687}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _Flip: {r: 1, g: 1, b: 1, a: 1}
     - _RendererColor: {r: 1, g: 1, b: 1, a: 1}

--- a/Assets/Resources/Prefabs/Buildings/BlueTeamBuildings/Barrack.prefab
+++ b/Assets/Resources/Prefabs/Buildings/BlueTeamBuildings/Barrack.prefab
@@ -451,7 +451,6 @@ GameObject:
   - component: {fileID: 2109365246691504876}
   - component: {fileID: 3893842900933242695}
   - component: {fileID: 6592754400457505827}
-  - component: {fileID: 8786623340795475057}
   m_Layer: 5
   m_Name: HealthUI
   m_TagString: Untagged
@@ -466,17 +465,17 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7225575676687105678}
-  m_LocalRotation: {x: 0, y: 0.70710677, z: -0.70710677, w: 0}
-  m_LocalPosition: {x: 0, y: 0, z: 7.5}
+  m_LocalRotation: {x: -1, y: -0, z: -0, w: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0.32}
   m_LocalScale: {x: 6, y: 4, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 7322513364056972645}
-  m_Father: {fileID: 1856497004635291874}
+  m_Father: {fileID: 5521551856617953037}
   m_LocalEulerAnglesHint: {x: 90, y: 90, z: -90}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 2.48}
+  m_AnchoredPosition: {x: 0, y: -0}
   m_SizeDelta: {x: 1, y: 0.1}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!223 &2109365246691504876
@@ -542,18 +541,6 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
---- !u!114 &8786623340795475057
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7225575676687105678}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8165f1437a28640a0ae6281c4da24599, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &7566681799950834487
 GameObject:
   m_ObjectHideFlags: 0
@@ -629,6 +616,52 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &7710359258993267043
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5521551856617953037}
+  - component: {fileID: 3159491998414565305}
+  m_Layer: 0
+  m_Name: UI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5521551856617953037
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7710359258993267043}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0.7071068, z: -0.7071068, w: 0}
+  m_LocalPosition: {x: 0, y: 3, z: 7.500002}
+  m_LocalScale: {x: 0.9999995, y: 0.99999976, z: 0.99999976}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7933589055565119277}
+  - {fileID: 7215432398618324287}
+  m_Father: {fileID: 1856497004635291874}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3159491998414565305
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7710359258993267043}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8165f1437a28640a0ae6281c4da24599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &7981699838410517833
 GameObject:
   m_ObjectHideFlags: 0
@@ -677,7 +710,6 @@ GameObject:
   - component: {fileID: 4115602789428182806}
   - component: {fileID: 739130224819731431}
   - component: {fileID: 2890730775603964873}
-  - component: {fileID: 1780384935411359512}
   m_Layer: 5
   m_Name: ProgressUI
   m_TagString: Untagged
@@ -692,17 +724,17 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8226649263902287836}
-  m_LocalRotation: {x: 0, y: 0.70710677, z: -0.70710677, w: 0}
-  m_LocalPosition: {x: 0, y: 0, z: 6}
+  m_LocalRotation: {x: -1, y: -0, z: -0, w: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0.34}
   m_LocalScale: {x: 6, y: 4, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5929826810582200607}
-  m_Father: {fileID: 1856497004635291874}
+  m_Father: {fileID: 5521551856617953037}
   m_LocalEulerAnglesHint: {x: 90, y: 90, z: -90}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0.97999966}
+  m_AnchoredPosition: {x: 0, y: -1.5}
   m_SizeDelta: {x: 1, y: 0.1}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!223 &4115602789428182806
@@ -768,18 +800,6 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
---- !u!114 &1780384935411359512
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8226649263902287836}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8165f1437a28640a0ae6281c4da24599, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1856497004635167330
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -797,8 +817,20 @@ PrefabInstance:
       value: Clickable
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: 7036859d28e2cb84c9948a1fcf49fe95, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.45
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 7036859d28e2cb84c9948a1fcf49fe95, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 7036859d28e2cb84c9948a1fcf49fe95, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 7036859d28e2cb84c9948a1fcf49fe95, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -49.782536
+      value: -55.22
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: 7036859d28e2cb84c9948a1fcf49fe95, type: 3}
       propertyPath: m_LocalPosition.y
@@ -806,7 +838,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: 7036859d28e2cb84c9948a1fcf49fe95, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -54.501984
+      value: -55.03
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: 7036859d28e2cb84c9948a1fcf49fe95, type: 3}
       propertyPath: m_LocalRotation.w
@@ -841,10 +873,7 @@ PrefabInstance:
     m_AddedGameObjects:
     - targetCorrespondingSourceObject: {fileID: 400000, guid: 7036859d28e2cb84c9948a1fcf49fe95, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 7933589055565119277}
-    - targetCorrespondingSourceObject: {fileID: 400000, guid: 7036859d28e2cb84c9948a1fcf49fe95, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 7215432398618324287}
+      addedObject: {fileID: 5521551856617953037}
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 100000, guid: 7036859d28e2cb84c9948a1fcf49fe95, type: 3}
       insertIndex: -1
@@ -886,8 +915,8 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 8.197476, y: 6.1805115, z: 4.80888}
-  m_Center: {x: 0.06949139, y: 0.04327774, z: 1.8621994}
+  m_Size: {x: 6.900138, y: 7.3973494, z: 4.808879}
+  m_Center: {x: -0.11670639, y: -0.014672456, z: 1.8622}
 --- !u!114 &8515307855472878936
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Prefabs/Buildings/BlueTeamBuildings/Command.prefab
+++ b/Assets/Resources/Prefabs/Buildings/BlueTeamBuildings/Command.prefab
@@ -101,7 +101,6 @@ GameObject:
   - component: {fileID: 3708363863161457725}
   - component: {fileID: 3941821554305914658}
   - component: {fileID: 3285437423883933124}
-  - component: {fileID: 75730478932624316}
   m_Layer: 5
   m_Name: HealthUI
   m_TagString: Untagged
@@ -116,17 +115,17 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 820722651657190751}
-  m_LocalRotation: {x: -0.5, y: 0.5, z: -0.5, w: 0.5}
-  m_LocalPosition: {x: 0, y: 0, z: 13.11}
-  m_LocalScale: {x: 8.5, y: 4, z: 1}
+  m_LocalRotation: {x: -1, y: -0, z: -0, w: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 4.4}
+  m_LocalScale: {x: 14.45, y: 6, z: 1.6999998}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 3955704623250339814}
-  m_Father: {fileID: 5353990028829965593}
+  m_Father: {fileID: 4275857680229709589}
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: -90}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -2.5, y: -0.03}
+  m_AnchoredPosition: {x: 1.2289205, y: -5.7000003}
   m_SizeDelta: {x: 1, y: 0.1}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!223 &3708363863161457725
@@ -192,18 +191,6 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
---- !u!114 &75730478932624316
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 820722651657190751}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8165f1437a28640a0ae6281c4da24599, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1709466852826518416
 GameObject:
   m_ObjectHideFlags: 0
@@ -216,7 +203,6 @@ GameObject:
   - component: {fileID: 1612124577580642443}
   - component: {fileID: 5387167643904248188}
   - component: {fileID: 7854403925907148098}
-  - component: {fileID: 4914341475568640411}
   m_Layer: 5
   m_Name: ProgressUI
   m_TagString: Untagged
@@ -231,17 +217,17 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1709466852826518416}
-  m_LocalRotation: {x: -0.5, y: 0.5, z: -0.5, w: 0.5}
-  m_LocalPosition: {x: 0, y: 0, z: 11.65}
-  m_LocalScale: {x: 8.5, y: 4, z: 1}
+  m_LocalRotation: {x: -1, y: -0, z: -0, w: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 4.4}
+  m_LocalScale: {x: 14.45, y: 6, z: 1.6999998}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5297329191450108999}
-  m_Father: {fileID: 5353990028829965593}
+  m_Father: {fileID: 4275857680229709589}
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: -90}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -1.5, y: -0.03}
+  m_AnchoredPosition: {x: 1.2289243, y: -7.9}
   m_SizeDelta: {x: 1, y: 0.1}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!223 &1612124577580642443
@@ -307,18 +293,6 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
---- !u!114 &4914341475568640411
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1709466852826518416}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8165f1437a28640a0ae6281c4da24599, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &2053277147603710275
 GameObject:
   m_ObjectHideFlags: 0
@@ -630,6 +604,52 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6282577883433172931
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4275857680229709589}
+  - component: {fileID: 7611194339366454778}
+  m_Layer: 0
+  m_Name: UI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4275857680229709589
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6282577883433172931}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.5, y: -0.5, z: -0.5, w: 0.5}
+  m_LocalPosition: {x: -7, y: 0.69289494, z: 17.674784}
+  m_LocalScale: {x: 0.5882353, y: 0.6666667, z: 0.5882353}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 723278901958165943}
+  - {fileID: 4036599316999504790}
+  m_Father: {fileID: 5353990028829965593}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7611194339366454778
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6282577883433172931}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8165f1437a28640a0ae6281c4da24599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &8486678163595839873
 GameObject:
   m_ObjectHideFlags: 0
@@ -797,8 +817,20 @@ PrefabInstance:
       value: Clickable
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: 637b3bb1a53fd584b8b2f29eddb05290, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 637b3bb1a53fd584b8b2f29eddb05290, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 637b3bb1a53fd584b8b2f29eddb05290, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 637b3bb1a53fd584b8b2f29eddb05290, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -55.481525
+      value: -57.36
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: 637b3bb1a53fd584b8b2f29eddb05290, type: 3}
       propertyPath: m_LocalPosition.y
@@ -806,7 +838,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: 637b3bb1a53fd584b8b2f29eddb05290, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -43.51653
+      value: -42.96
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: 637b3bb1a53fd584b8b2f29eddb05290, type: 3}
       propertyPath: m_LocalRotation.w
@@ -841,10 +873,7 @@ PrefabInstance:
     m_AddedGameObjects:
     - targetCorrespondingSourceObject: {fileID: 400000, guid: 637b3bb1a53fd584b8b2f29eddb05290, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 4036599316999504790}
-    - targetCorrespondingSourceObject: {fileID: 400000, guid: 637b3bb1a53fd584b8b2f29eddb05290, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 723278901958165943}
+      addedObject: {fileID: 4275857680229709589}
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 100000, guid: 637b3bb1a53fd584b8b2f29eddb05290, type: 3}
       insertIndex: -1
@@ -936,6 +965,9 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   deMouseHoverEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  draggedEvent:
     m_PersistentCalls:
       m_Calls: []
 --- !u!114 &5636797319355405754

--- a/Assets/Resources/Prefabs/Buildings/BlueTeamBuildings/Defender.prefab
+++ b/Assets/Resources/Prefabs/Buildings/BlueTeamBuildings/Defender.prefab
@@ -123,7 +123,6 @@ GameObject:
   - component: {fileID: 8120987137322569063}
   - component: {fileID: 6937135946659651031}
   - component: {fileID: 9202139147428475304}
-  - component: {fileID: 9041839907606476896}
   m_Layer: 5
   m_Name: HealthUI
   m_TagString: Untagged
@@ -138,17 +137,17 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4967860239936312132}
-  m_LocalRotation: {x: -0, y: 0.7071068, z: -0.7071068, w: 0}
-  m_LocalPosition: {x: 0, y: 0, z: 10}
-  m_LocalScale: {x: 6, y: 4, z: 1}
+  m_LocalRotation: {x: -1, y: -0, z: -0, w: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0.4633436}
+  m_LocalScale: {x: 8.100004, y: 6, z: 1.3500004}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5467696686842945166}
-  m_Father: {fileID: 1631118528070162760}
+  m_Father: {fileID: 5284298042199687531}
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: -90}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.05, y: 1}
+  m_AnchoredPosition: {x: 0.12851977, y: 3.9805782}
   m_SizeDelta: {x: 1, y: 0.1}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!223 &8120987137322569063
@@ -214,18 +213,6 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
---- !u!114 &9041839907606476896
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4967860239936312132}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8165f1437a28640a0ae6281c4da24599, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &5067341225507093361
 GameObject:
   m_ObjectHideFlags: 0
@@ -515,6 +502,52 @@ MonoBehaviour:
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
+--- !u!1 &7261462598759869131
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5284298042199687531}
+  - component: {fileID: 2358860412343272432}
+  m_Layer: 0
+  m_Name: UI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5284298042199687531
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7261462598759869131}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0.7071068, z: -0.7071068, w: 0}
+  m_LocalPosition: {x: 0.04520276, y: 1, z: 7.3462825}
+  m_LocalScale: {x: 0.74074036, y: 0.66666645, z: 0.74074054}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7550320579201040974}
+  - {fileID: 8910842518268378008}
+  m_Father: {fileID: 1631118528070162760}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2358860412343272432
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7261462598759869131}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8165f1437a28640a0ae6281c4da24599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &7288227954135958446
 GameObject:
   m_ObjectHideFlags: 0
@@ -602,7 +635,6 @@ GameObject:
   - component: {fileID: 2368487654006176499}
   - component: {fileID: 4724480337553654724}
   - component: {fileID: 4092076563657126972}
-  - component: {fileID: 8566336563041512076}
   m_Layer: 5
   m_Name: ProgressUI
   m_TagString: Untagged
@@ -617,17 +649,17 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8424626192490231382}
-  m_LocalRotation: {x: -0, y: 0.7071068, z: -0.7071068, w: 0}
-  m_LocalPosition: {x: 0, y: 0, z: 8.5}
-  m_LocalScale: {x: 6, y: 4, z: 1}
+  m_LocalRotation: {x: -1, y: -0, z: -0, w: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0.4633436}
+  m_LocalScale: {x: 8.100004, y: 6, z: 1.3500004}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 6608531410282228349}
-  m_Father: {fileID: 1631118528070162760}
+  m_Father: {fileID: 5284298042199687531}
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: -90}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.05, y: 0}
+  m_AnchoredPosition: {x: 0.12851977, y: 1.7283874}
   m_SizeDelta: {x: 1, y: 0.1}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!223 &2368487654006176499
@@ -693,18 +725,6 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
---- !u!114 &8566336563041512076
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8424626192490231382}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8165f1437a28640a0ae6281c4da24599, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &9052716326207952959
 GameObject:
   m_ObjectHideFlags: 0
@@ -797,8 +817,20 @@ PrefabInstance:
       value: Clickable
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: f38b9a56b23e4df499eaede1c2276296, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: f38b9a56b23e4df499eaede1c2276296, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: f38b9a56b23e4df499eaede1c2276296, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: f38b9a56b23e4df499eaede1c2276296, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -39.28211
+      value: -37.42
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: f38b9a56b23e4df499eaede1c2276296, type: 3}
       propertyPath: m_LocalPosition.y
@@ -806,7 +838,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: f38b9a56b23e4df499eaede1c2276296, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -28.675257
+      value: -32.43
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: f38b9a56b23e4df499eaede1c2276296, type: 3}
       propertyPath: m_LocalRotation.w
@@ -841,10 +873,7 @@ PrefabInstance:
     m_AddedGameObjects:
     - targetCorrespondingSourceObject: {fileID: 400000, guid: f38b9a56b23e4df499eaede1c2276296, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 7550320579201040974}
-    - targetCorrespondingSourceObject: {fileID: 400000, guid: f38b9a56b23e4df499eaede1c2276296, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 8910842518268378008}
+      addedObject: {fileID: 5284298042199687531}
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 100000, guid: f38b9a56b23e4df499eaede1c2276296, type: 3}
       insertIndex: -1
@@ -886,8 +915,8 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 3.4463933, y: 3.6087694, z: 8.971036}
-  m_Center: {x: 0.14651155, y: -0.0037829876, z: 2.7544622}
+  m_Size: {x: 3.6065662, y: 3.6087694, z: 8.971036}
+  m_Center: {x: 0.06642527, y: -0.0037829082, z: 2.7544618}
 --- !u!114 &-6744043205098766824
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Prefabs/Buildings/BlueTeamBuildings/PopulationBuilding.prefab
+++ b/Assets/Resources/Prefabs/Buildings/BlueTeamBuildings/PopulationBuilding.prefab
@@ -111,6 +111,52 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &962874817413094932
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4593416296305904203}
+  - component: {fileID: 8606287287628782902}
+  m_Layer: 0
+  m_Name: UI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4593416296305904203
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 962874817413094932}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0.7071068, z: -0.7071068, w: 0}
+  m_LocalPosition: {x: 7.045107, y: 7, z: 4.887996}
+  m_LocalScale: {x: 0.9999995, y: 0.99999976, z: 0.99999976}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 269709490982223145}
+  - {fileID: 3252214098087667843}
+  m_Father: {fileID: 3850242999581741051}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8606287287628782902
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 962874817413094932}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8165f1437a28640a0ae6281c4da24599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1158099183676898899
 GameObject:
   m_ObjectHideFlags: 0
@@ -362,7 +408,6 @@ GameObject:
   - component: {fileID: 8525289644816151819}
   - component: {fileID: 7669807613793370334}
   - component: {fileID: 7076700494658744763}
-  - component: {fileID: 8278725384730522925}
   m_Layer: 5
   m_Name: ProgressUI
   m_TagString: Untagged
@@ -377,17 +422,17 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1289352117265330361}
-  m_LocalRotation: {x: -0, y: 0.7071068, z: -0.7071068, w: 0}
-  m_LocalPosition: {x: 0, y: 0, z: 6}
+  m_LocalRotation: {x: -1, y: -0, z: -0, w: 0}
+  m_LocalPosition: {x: 0, y: 0, z: -4.885619}
   m_LocalScale: {x: 6, y: 4, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8474012765300955253}
-  m_Father: {fileID: 3850242999581741051}
+  m_Father: {fileID: 4593416296305904203}
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: -90}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.37999976, y: 0}
+  m_AnchoredPosition: {x: 7.425119, y: 1.1120038}
   m_SizeDelta: {x: 1, y: 0.1}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!223 &8525289644816151819
@@ -453,18 +498,6 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
---- !u!114 &8278725384730522925
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1289352117265330361}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8165f1437a28640a0ae6281c4da24599, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1985396603789985002
 GameObject:
   m_ObjectHideFlags: 0
@@ -641,7 +674,6 @@ GameObject:
   - component: {fileID: 617476338710453101}
   - component: {fileID: 1179187279076427010}
   - component: {fileID: 2931198805607154499}
-  - component: {fileID: 7809436257183007485}
   m_Layer: 5
   m_Name: HealthUI
   m_TagString: Untagged
@@ -656,17 +688,17 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7278360412559402455}
-  m_LocalRotation: {x: -0, y: 0.7071068, z: -0.7071068, w: 0}
-  m_LocalPosition: {x: 0, y: 0, z: 7.5}
+  m_LocalRotation: {x: -1, y: -0, z: -0, w: 0}
+  m_LocalPosition: {x: 0, y: 0, z: -4.8856187}
   m_LocalScale: {x: 6, y: 4, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8352007468716509920}
-  m_Father: {fileID: 3850242999581741051}
+  m_Father: {fileID: 4593416296305904203}
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: -90}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.38, y: 1.5}
+  m_AnchoredPosition: {x: 7.4251184, y: 2.6120043}
   m_SizeDelta: {x: 1, y: 0.1}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!223 &617476338710453101
@@ -732,18 +764,6 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
---- !u!114 &7809436257183007485
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7278360412559402455}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8165f1437a28640a0ae6281c4da24599, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &7577777694619138757
 GameObject:
   m_ObjectHideFlags: 0
@@ -797,8 +817,16 @@ PrefabInstance:
       value: Clickable
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: 05035b78d90b21f43854dfe010ccd289, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 05035b78d90b21f43854dfe010ccd289, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 05035b78d90b21f43854dfe010ccd289, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -45.517227
+      value: -47.55
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: 05035b78d90b21f43854dfe010ccd289, type: 3}
       propertyPath: m_LocalPosition.y
@@ -806,7 +834,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: 05035b78d90b21f43854dfe010ccd289, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -33.39893
+      value: -32.65
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: 05035b78d90b21f43854dfe010ccd289, type: 3}
       propertyPath: m_LocalRotation.w
@@ -841,10 +869,7 @@ PrefabInstance:
     m_AddedGameObjects:
     - targetCorrespondingSourceObject: {fileID: 400000, guid: 05035b78d90b21f43854dfe010ccd289, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 269709490982223145}
-    - targetCorrespondingSourceObject: {fileID: 400000, guid: 05035b78d90b21f43854dfe010ccd289, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 3252214098087667843}
+      addedObject: {fileID: 4593416296305904203}
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 100000, guid: 05035b78d90b21f43854dfe010ccd289, type: 3}
       insertIndex: -1

--- a/Assets/Resources/Prefabs/Buildings/BlueTeamBuildings/ResourceBuilding.prefab
+++ b/Assets/Resources/Prefabs/Buildings/BlueTeamBuildings/ResourceBuilding.prefab
@@ -12,7 +12,6 @@ GameObject:
   - component: {fileID: 1743187759194680409}
   - component: {fileID: 6801412112682483309}
   - component: {fileID: 7186343339575514235}
-  - component: {fileID: 138335002161835}
   m_Layer: 5
   m_Name: HealthUI
   m_TagString: Untagged
@@ -27,17 +26,17 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 170193477888146098}
-  m_LocalRotation: {x: -0, y: 0.7071068, z: -0.7071068, w: 0}
-  m_LocalPosition: {x: 0, y: 0, z: 8.09}
+  m_LocalRotation: {x: -1, y: -0, z: -0, w: 0}
+  m_LocalPosition: {x: 0, y: 0, z: -1.7506852}
   m_LocalScale: {x: 6, y: 4, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8740199537967686660}
-  m_Father: {fileID: 7725685943264654335}
+  m_Father: {fileID: 110980571836203391}
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: -90}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.23, y: 1.5}
+  m_AnchoredPosition: {x: -1.959902, y: 5.669337}
   m_SizeDelta: {x: 1, y: 0.1}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!223 &1743187759194680409
@@ -103,18 +102,6 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
---- !u!114 &138335002161835
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 170193477888146098}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8165f1437a28640a0ae6281c4da24599, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1057836946427486361
 GameObject:
   m_ObjectHideFlags: 0
@@ -491,7 +478,6 @@ GameObject:
   - component: {fileID: 7537372546267438339}
   - component: {fileID: 8775216373450384179}
   - component: {fileID: 6310457359805482300}
-  - component: {fileID: 1356228810458782136}
   m_Layer: 5
   m_Name: ProgressUI
   m_TagString: Untagged
@@ -506,17 +492,17 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6182523016584066962}
-  m_LocalRotation: {x: -0, y: 0.7071068, z: -0.7071068, w: 0}
-  m_LocalPosition: {x: 0, y: 0, z: 6.59}
+  m_LocalRotation: {x: -1, y: -0, z: -0, w: 0}
+  m_LocalPosition: {x: 0, y: 0, z: -1.750685}
   m_LocalScale: {x: 6, y: 4, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 6810424444121131139}
-  m_Father: {fileID: 7725685943264654335}
+  m_Father: {fileID: 110980571836203391}
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: -90}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.23, y: 0}
+  m_AnchoredPosition: {x: -1.959902, y: 4.169336}
   m_SizeDelta: {x: 1, y: 0.1}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!223 &7537372546267438339
@@ -582,18 +568,6 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
---- !u!114 &1356228810458782136
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6182523016584066962}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8165f1437a28640a0ae6281c4da24599, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &7037318883274978504
 GameObject:
   m_ObjectHideFlags: 0
@@ -744,6 +718,52 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8406621477315624680
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 110980571836203391}
+  - component: {fileID: 3115397083184361956}
+  m_Layer: 0
+  m_Name: UI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &110980571836203391
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8406621477315624680}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0.7071068, z: -0.7071068, w: 0}
+  m_LocalPosition: {x: -2.1899, y: 5, z: 2.4206665}
+  m_LocalScale: {x: 0.9999995, y: 0.99999976, z: 0.99999976}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6029983983062372815}
+  - {fileID: 856624086145166156}
+  m_Father: {fileID: 7725685943264654335}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3115397083184361956
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8406621477315624680}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8165f1437a28640a0ae6281c4da24599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &9162752956986142435
 GameObject:
   m_ObjectHideFlags: 0
@@ -797,16 +817,28 @@ PrefabInstance:
       value: Clickable
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: 520e20395d1150a4c94174228bde0499, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 520e20395d1150a4c94174228bde0499, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 520e20395d1150a4c94174228bde0499, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 520e20395d1150a4c94174228bde0499, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -46.185913
+      value: -45.1
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: 520e20395d1150a4c94174228bde0499, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.80706084
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: 520e20395d1150a4c94174228bde0499, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -41.227787
+      value: -45
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: 520e20395d1150a4c94174228bde0499, type: 3}
       propertyPath: m_LocalRotation.w
@@ -841,10 +873,7 @@ PrefabInstance:
     m_AddedGameObjects:
     - targetCorrespondingSourceObject: {fileID: 400000, guid: 520e20395d1150a4c94174228bde0499, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 6029983983062372815}
-    - targetCorrespondingSourceObject: {fileID: 400000, guid: 520e20395d1150a4c94174228bde0499, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 856624086145166156}
+      addedObject: {fileID: 110980571836203391}
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 100000, guid: 520e20395d1150a4c94174228bde0499, type: 3}
       insertIndex: -1

--- a/Assets/Resources/Prefabs/GridElement.prefab
+++ b/Assets/Resources/Prefabs/GridElement.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 3573689446639347818}
   - component: {fileID: 4504187751965033002}
   - component: {fileID: 2973886920064003261}
-  m_Layer: 0
+  m_Layer: 3
   m_Name: GridElement
   m_TagString: Clickable
   m_Icon: {fileID: 0}
@@ -120,9 +120,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 420c2370a83384ff0874b0288249e0e0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  isHovered: 0
   defaultMaterial: {fileID: 2100000, guid: d2677361d94094c57940a88735da3d9a, type: 2}
-  hoveredMaterial: {fileID: 2100000, guid: 44d8f569659104c2f84a83ad48aa033a, type: 2}
+  hoveredMaterial: {fileID: 2100000, guid: c22e4993a5fd94f4aa11503d214fc627, type: 2}
+  selectedMaterial: {fileID: 2100000, guid: 44d8f569659104c2f84a83ad48aa033a, type: 2}
   builtedMaterial: {fileID: 2100000, guid: 9545eeb2599484e5db08c80192fd2525, type: 2}
 --- !u!114 &2973886920064003261
 MonoBehaviour:
@@ -152,5 +152,8 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   deMouseHoverEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  draggedEvent:
     m_PersistentCalls:
       m_Calls: []

--- a/Assets/Scripts/Building/BuildingController.cs
+++ b/Assets/Scripts/Building/BuildingController.cs
@@ -11,41 +11,28 @@ public class BuildingController : MonoBehaviour
 {
     //--------- 변수 선언 위치 변경 (해윤) ---------//
     public Dictionary<int, Building> buildingDictionary = new Dictionary<int, Building>();
-    private Dictionary<string, GameObject> _buildingPrefabs = new Dictionary<string, GameObject>();
     private string _teamID;
     private int _buildingID;
     //---------------------------------------//
     public GameObject buildingObject;
-    public void Start()
+    
+    public void Awake()
     {
         _teamID = GameStatus.instance.teamID;
         _buildingID = 0;
-
-        // 폴더 경로에 있는 모든 GameObject를 Load해 unitPrefabsList에 임시로 저장
-        List<GameObject> buildingPrefabsList = new List<GameObject>(Resources.LoadAll<GameObject>($"Prefabs/Buildings/{_teamID}TeamBuildings"));
-
-        // foreach문으로 List 안에 있는 building 객체들을 다시 Dictionary로 저장
-        foreach (GameObject building in buildingPrefabsList)
-        {
-            if (!_buildingPrefabs.ContainsKey(building.name))
-            {
-                _buildingPrefabs.Add(building.name, building);
-            }
-        }
-
     }
 
-    public Building CreateBuilding(Vector3 buildingLocation, string buildingType)
+    public Building CreateBuilding(Vector3 buildingLocation, string buildingType, Vector3 rot)
     // 건물 생성
     {
         // 객체 생성
-        buildingObject = PhotonNetwork.Instantiate($"Prefabs/Buildings/{_teamID}TeamBuildings/{buildingType}", buildingLocation, Quaternion.Euler(new Vector3(-90, 90, 90)));
+        buildingObject = PhotonNetwork.Instantiate($"Prefabs/Buildings/{_teamID}TeamBuildings/{buildingType}", buildingLocation, Quaternion.Euler(rot));
         buildingObject.name = buildingType + _buildingID.ToString(); // 새로 생성될 오브젝트에 고유한 이름을 붙여줌
         GameObject gameObject = buildingObject; // SetClickedObject에 넣을 임의 변수 만듦 -> call by value로 되기 떄문에 buildingObject가 바뀌어도 값이 안바뀜
         // 좌클릭 했을 때 callback 함수 넣어줌
         buildingObject.GetComponent<ClickEventHandler>().leftClickDownEvent.AddListener((Vector3 pos) => GameManager.instance.SetClickedObject(gameObject));
-        Slider healthBar = buildingObject.transform.Find("HealthUI/CurrentHealth").GetComponent<Slider>();
-        Slider progressBar = buildingObject.transform.Find("ProgressUI/CurrentProgress").GetComponent<Slider>();
+        Slider healthBar = buildingObject.transform.Find("UI/HealthUI/CurrentHealth").GetComponent<Slider>();
+        Slider progressBar = buildingObject.transform.Find("UI/ProgressUI/CurrentProgress").GetComponent<Slider>();
         healthBar.gameObject.SetActive(true);
         progressBar.gameObject.SetActive(true);
         Building newBuilding;

--- a/Assets/Scripts/Click/ClickManager.cs
+++ b/Assets/Scripts/Click/ClickManager.cs
@@ -6,6 +6,8 @@ using System;
 using UnityEngine.UIElements;
 using UnityEditor.Overlays;
 using Unity.AI.Navigation;
+using System.Linq;
+using Photon.Chat.Demo;
 
 public class ClickManager : MonoBehaviour
 {
@@ -17,6 +19,16 @@ public class ClickManager : MonoBehaviour
         public Vector3 bottomRight { get; set; } // 오른쪽 하단
 
     };
+    // ----------------- 준현 ------------------
+    public GameObject grid;
+    public List<Collider> detectedGrids;
+    public List<Collider> constructionGrids;
+
+    private float _buildingRange;
+    private Vector3 _range;
+    private Vector3 areaPos;
+    private LayerMask _layerMask = 1 << 3;
+    // ----------------------------------------
 
     private float _distance = 300f;
     private Vector3 _dragStartPoint;
@@ -88,7 +100,7 @@ public class ClickManager : MonoBehaviour
 
     private void Click(int side, Action<GameObject, Vector3> action)    //클릭 시에 ray cast
     {
-        //화면 밖의 클릭은 아무런 동작하지 않도록 하기 위한 변수 및 조건문
+        //화면 의 클릭은 아무런 동작하지 않도록 하기 위한 변수 및 조건문
         #region 화면 밖에 대한 변수 및 조건문
 
         float screenWidth = Screen.width;
@@ -116,6 +128,8 @@ public class ClickManager : MonoBehaviour
             // Debug.Log($"{hit.collider.gameObject.name}, {hit.point}");
         }
     }
+
+    // -----------------------------------준현 수정-------------------------------------
     private void MouseHover()   //항상 ray cast
     {
         float screenWidth = Screen.width;
@@ -135,19 +149,114 @@ public class ClickManager : MonoBehaviour
             Debug.DrawRay(ray.origin, ray.direction * _distance, Color.green);
         }
 
-        if (Physics.Raycast(ray, out hit, _distance) && hit.collider.CompareTag("Clickable"))
+        if (Physics.Raycast(ray, out hit, _distance))
         {
-            if (hoverObj != hit.collider.gameObject)
+            if(grid.activeSelf)
             {
-                if (hoverObj != null)
-                {
-                    hoverObj.GetComponent<ClickEventHandler>().DeMouseHover(hit.point);
-                }
-                hoverObj = hit.collider.gameObject;
+                _range = new Vector3(_buildingRange,1,_buildingRange);
+                areaPos = new Vector3(hit.point.x, 0.01f, hit.point.z);
+                
+                // 넓은 범위
+                Collider[] detectedObjs = Physics.OverlapBox(new Vector3(areaPos.x, 0.02f, areaPos.z),new Vector3(12.5f,1f,12.5f),Quaternion.identity,_layerMask);
+                // 건물이 지어지는 Grid만
+                Collider[] constructionGrid = Physics.OverlapBox(new Vector3(areaPos.x, 0.02f, areaPos.z),_range*2,Quaternion.identity,_layerMask);
+
+                UpdateGridMeshToDefault(detectedObjs);
+                // UpdateGridMeshToDefault(constructionGrid);
+
+                // 기존 리스트에서 빠져나갈 요소들의 Mesh값을 바꿔줬으니 새로 받은 Grid 배열을 List로 추가해줌
+                detectedGrids = detectedObjs.ToList();
+                constructionGrids = constructionGrid.ToList();
+                // 최신화된 Grid List의 요소들을 검사해서 Builted && Hovered 상태가 아니면 Mesh를 바꿔준다.
+                UpdateGridMeshToHovered();
+                UpdateGridMeshToSelected();
+               
             }
-            hit.collider.GetComponent<ClickEventHandler>().OnMouseHover(hit.point);
+            if(hit.collider.CompareTag("Clickable"))
+            {
+                if (hoverObj != hit.collider.gameObject)
+                {
+                    if (hoverObj != null)
+                    {
+                        hoverObj.GetComponent<ClickEventHandler>().DeMouseHover(hit.point);
+                    }
+                    hoverObj = hit.collider.gameObject;
+                }
+                hit.collider.GetComponent<ClickEventHandler>().OnMouseHover(hit.point);
+            }
         }
     }
+
+    public void SetBuildingRange(float range)
+    {
+        _buildingRange = range;
+    }
+    private void UpdateGridMeshToDefault(Collider[] detectedObjs)
+    {
+        // 기존 Grid List 요소를 검사해서 새로 감지된 Grid 배열에 요소가 없다면
+        // 마우스의 범위에 벗어난것이므로 요소의 Mesh값을 Default값으로 바꾼다.
+        // 이때 Builted 상태인 Grid는 Mesh값 업데이트 X
+        if(detectedGrids.Count != 0)
+        {
+            foreach(Collider obj in detectedGrids)
+            {
+                if(obj.TryGetComponent(out GridEvent grid))
+                {
+                    if(!detectedObjs.Contains(obj) && !grid.GetIsBuilted())
+                    {
+                        grid.SetDefault();
+                        grid.ChangeMesh();
+                    }
+                    grid.UnSetRender();
+                }
+            }
+        }
+    }
+
+    private void UpdateGridMeshToHovered()
+    {
+        foreach(Collider obj in detectedGrids)
+        {
+            if(obj.TryGetComponent(out GridEvent grid))
+            {
+                if(!grid.GetIsBuilted())
+                {
+                    grid.SetHovered();
+                    grid.ChangeMesh();
+                }
+                grid.SetRander();
+            }
+        }
+    }
+
+    private void UpdateGridMeshToSelected()
+    {
+        foreach(Collider obj in constructionGrids)
+        {
+            if(obj.TryGetComponent(out GridEvent grid))
+            {
+                if(!grid.GetIsBuilted())
+                {
+                    grid.SetSelected();
+                    grid.ChangeMesh();
+                }
+            }
+        }
+    }
+
+    public void SetGridsToBuilted()
+    {
+        foreach(Collider obj in constructionGrids)
+        {
+            if(obj.TryGetComponent(out GridEvent grid))
+            {
+                grid.SetBuilted();
+                grid.ChangeMesh();
+            }
+        }
+    }
+    // -----------------------------------------------------------------------------------
+
 
     public void Drag()  //미완성
     {

--- a/Assets/Scripts/Grid/GridEvent.cs
+++ b/Assets/Scripts/Grid/GridEvent.cs
@@ -1,23 +1,33 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
+using Photon.Pun;
+using Unity.VisualScripting;
 using UnityEngine;
 
 public class GridEvent : MonoBehaviour
 {
+    public enum State
+    {
+        Default = 0,
+        Hovered = 1,
+        Selected = 2,
+        Builted = 3
+    }
+
     public Material defaultMaterial;
     public Material hoveredMaterial;
-    private bool _isHovered = false;
-    private bool _isBuilted = false;
+    public Material selectedMaterial;
+    public State gridState = State.Default;
     public Material builtedMaterial;
     private ClickEventHandler _clickEventHandler;
     private MeshRenderer _meshRenderer;
 
     void Start()
     {
+        UnSetRender();
         _meshRenderer = GetComponent<MeshRenderer>();
         _clickEventHandler = GetComponent<ClickEventHandler>();
-        _clickEventHandler.mouseHoverEvent.AddListener((Vector3 pos) => OnMouseHovered());
-        _clickEventHandler.deMouseHoverEvent.AddListener((Vector3 pos) => OnMouseHoveredOut());
         _clickEventHandler.leftClickDownEvent.AddListener((Vector3 pos) => {
             GameManager.instance.CreateBuilding(gameObject.transform.position);
             GameManager.instance.SetClickedObject(GameManager.instance.ground);
@@ -26,44 +36,64 @@ public class GridEvent : MonoBehaviour
     }
     public void OnBuiltIn()
     {
-        _isBuilted = true;
-        ChangeMesh();
-    }
-    public void OnMouseHovered()
-    {
-        SetisHovered();
+        SetBuilted();
         ChangeMesh();
     }
 
-    public void OnMouseHoveredOut()
+    public void UnSetRender()
     {
-        UnSetHovered();
-        ChangeMesh();
+        gameObject.GetComponent<Renderer>().enabled = false;
+    }
+    public void SetRander()
+    {
+        gameObject.GetComponent<Renderer>().enabled = true;
+    }
+    public void SetBuilted()
+    {
+        gridState = State.Builted;
+    }
+    public void SetHovered()
+    {
+        gridState = State.Hovered;
+    }
+    public void SetDefault()
+    {
+        gridState = State.Default;
+    }
+    public void SetSelected()
+    {
+        gridState = State.Selected;
     }
 
-    public void SetisHovered()
+    public bool GetIsHovered()
     {
-        if(!_isHovered)
-        {
-            _isHovered = true;
-        }
+        return gridState == State.Hovered ? true : false;
     }
-
-    public void UnSetHovered()
+    public bool GetIsBuilted()
     {
-        if(_isHovered)
-        {
-            _isHovered = false;
-        }
+        return gridState == State.Builted ? true : false;
     }
+    public bool GetIsSelected()
+    {
+        return gridState == State.Selected ? true : false; 
+    }
+    
     public void ChangeMesh()
     {
-        if(!_isBuilted)
+        switch(gridState)
         {
-            _meshRenderer.material = _isHovered ? hoveredMaterial : defaultMaterial;
-        } else {
-            _meshRenderer.material = builtedMaterial;
-            gameObject.tag = "Untagged";
+            case State.Default:
+                _meshRenderer.material = defaultMaterial;
+                break;
+            case State.Hovered:
+                _meshRenderer.material = hoveredMaterial;
+                break;
+            case State.Selected:
+                _meshRenderer.material = selectedMaterial;
+                break;
+            case State.Builted:
+                _meshRenderer.material = builtedMaterial;
+                break;
         }
     }
 }

--- a/Assets/Scripts/InGame/GameManager.cs
+++ b/Assets/Scripts/InGame/GameManager.cs
@@ -46,6 +46,7 @@ public class GameManager : MonoBehaviour
     void Start()
     {
         currentUI.Show();
+        buildingController.CreateBuilding(new Vector3(0,0,0), "Command", new Vector3(-90, 0, 90));
     }
 
     // ================== 클릭 관련 함수 ======================
@@ -158,8 +159,13 @@ public class GameManager : MonoBehaviour
     }
     private async Task DelayBuildingCreation(Vector3 buildingPos)
     {
+        // ----- 임시로 일단 쓴거임 -------
+        // _detectedObjects = GameStatus.instance.GetDetectedObjects();
+        // UpdateGridMeshToBuilted(_detectedObjects);
+        // ----- 임시로 일단 쓴거임 -------
+
         //AddComponent로 넣으면 inspector창에서 초기화한 값이 안들어가고 가장 초기의 값이 들어감. inspector 창으로 초기화를 하고 싶으면 script상 초기화 보다는 prefab을 건드리는게 나을듯
-        Building building = buildingController.CreateBuilding(buildingPos, buildingType);
+        Building building = buildingController.CreateBuilding(buildingPos, buildingType, new Vector3(-90, 90, 90));
         building.InitTime();
         await StartTimer(building.loadingTime, (float time) => UpdateBuildingHealth(building, time));
 
@@ -170,6 +176,17 @@ public class GameManager : MonoBehaviour
         building.currentHealth = Mathf.FloorToInt(building.currentHealth); // 소수점 아래자리 버리기
         buildingController.SetBuildingState(building, 1, "None");
         ReloadBuildingUI(building);
+    }
+    
+    private void UpdateGridMeshToBuilted(List<Collider> detectedObjects)
+    {
+        foreach(Collider detectedobject in detectedObjects)
+        {
+            if(detectedobject.TryGetComponent(out GridEvent grid))
+            {
+                grid.OnBuiltIn();
+            }
+        }
     }
 
     private void UpdateBuildingHealth(Building building, float time)

--- a/Assets/Scripts/InGame/GameStatus.cs
+++ b/Assets/Scripts/InGame/GameStatus.cs
@@ -33,7 +33,6 @@ public class GameStatus : MonoBehaviour
     public int currentUnitCount { get; set; }
     public int maxBuildingCount { get; set; }
     public int currentBuildingCount { get; set; }
-
     public void InitGameStatus()
     {
         teamID = "Blue";

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -11,11 +11,12 @@ TagManager:
   - LoginBtn
   - QuitBtn
   - InProgress
+  - BarrackUI
   layers:
   - Default
   - TransparentFX
   - Ignore Raycast
-  - 
+  - Grid
   - Water
   - UI
   - 


### PR DESCRIPTION
Grid객체에 상태를 추가해서 Default, Hovered, Selected, Bulited 4가지 상태로 Grid를 관리할 수 있도록 수정
마우스에 맞춰서 커서 주변 16칸정도만 Grid가 보이게 수정했고
중간에 건물이 설치될 부분에는 초록색으로 따로 표시해놨음
수정해야할거는 Grid 관리를 지금 ClickManager에서 하고있고, Grid와 관련된 데이터도 ClickManger에서 담당하고있음
건물 생성은 GameManager에서 담당하고 있어서 건물이 생성됐을 때 선택된 Grid를 가져와서 Builted State로 바꿔야하는데
GameManger에서 ClickManger에 접근해서 데이터를 가져오면 Manager간에 독립성이 깨져서 구조 고민을 해야함