### PR TITLE
[fix] 유닛 죽을 때 코루틴 실행되는거 수정

### DIFF
--- a/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -56,9 +56,9 @@ MonoBehaviour:
   - DestroyEntity
   - SyncSetTag
   - SetStateDestroy
-  - SetState
   - SetOtherStartingPoint
   - SetTarget
+  - ChangeState
   DisableAutoOpenWizard: 1
   ShowSettings: 0
   DevRegionSetOnce: 1

--- a/Assets/Scripts/InGame/GameManager.cs
+++ b/Assets/Scripts/InGame/GameManager.cs
@@ -574,6 +574,9 @@ public class GameManager : MonoBehaviour
         if(orderedObjs.TryGetComponent(out Unit selectedUnit))
         {
             Debug.Log("A땅 목적지 : " + newLocation.ToString() + "유닛 상태 : " + selectedUnit.order + " / " + selectedUnit.state);
+            if(selectedUnit.state == Unit.State.Die){
+                return;
+            }
 
             selectedUnit.destination = newLocation;
 
@@ -611,7 +614,9 @@ public class GameManager : MonoBehaviour
         foreach (GameObject go in clickedObject)
         {
             go.TryGetComponent(out Unit selectedUnit);
-
+            if(selectedUnit.state == Unit.State.Die){
+                return;
+            }
             if (selectedUnit == null)
             {
                 continue;
@@ -629,7 +634,7 @@ public class GameManager : MonoBehaviour
     {
         Unit unit = ally.GetComponent<Unit>();
         enemy.TryGetComponent(out Entity enemyEntity);
-        if (enemyEntity == null || unit.teamID == enemyEntity.teamID)
+        if (enemyEntity == null || unit.teamID == enemyEntity.teamID || unit.state == Unit.State.Die)
         {
             return;
         }
@@ -640,7 +645,7 @@ public class GameManager : MonoBehaviour
                 // Debug.Log(enemy.name + " 가 어택 리스트에 추가됨");
                 unit.attackList.Add(enemy);
             }
-            if (unit.order == Unit.Order.Move || unit.state == Unit.State.Attack)
+            if (unit.order == Unit.Order.Move || unit.state == Unit.State.Attack || unit.state == Unit.State.Die)
             {
                 return;
             }
@@ -650,7 +655,7 @@ public class GameManager : MonoBehaviour
                 StopCoroutine(unit.unitBehaviour);
             }
             if(enemy != null){
-                Debug.Log($"---------------------------------------name: {enemy.name}");
+                //Debug.Log($"---------------------------------------name: {enemy.name}");
                 ally.GetComponent<PhotonView>().RPC("SetTarget", RpcTarget.All, enemy.GetComponent<PhotonView>().ViewID);
             }
             unit.unitBehaviour = StartCoroutine(unitController.Attack(ally, enemy));
@@ -668,7 +673,7 @@ public class GameManager : MonoBehaviour
         int order; //이거 이제 3번이 맞겠다
         Unit unit = ally.GetComponent<Unit>();
         enemy.TryGetComponent(out Entity enemyEntity);
-        if (enemyEntity == null || unit.teamID == enemyEntity.teamID)
+        if (enemyEntity == null || unit.teamID == enemyEntity.teamID || unit.state == Unit.State.Die)
         {
             return;
         }
@@ -684,6 +689,7 @@ public class GameManager : MonoBehaviour
             {
                 return;
             }*/
+            
             if (unit.state == Unit.State.Idle || (unit.order == Unit.Order.Offensive && unit.state == Unit.State.Move))
             {
                 if (unit.unitBehaviour != null)

--- a/Assets/Scripts/Unit/Unit.cs
+++ b/Assets/Scripts/Unit/Unit.cs
@@ -190,7 +190,7 @@ public abstract class Unit : Entity
         }
     }
 
-    [PunRPC]
+    
     public void SetState(string newState)
     {
         switch (newState)
@@ -227,6 +227,7 @@ public abstract class Unit : Entity
         }
     }
 
+    [PunRPC]
     public void ChangeState(string newState)
     {
         switch (state)
@@ -260,13 +261,16 @@ public abstract class Unit : Entity
                 }
                 SetState(newState);
                 break;
+            
+            case State.Die:
+                break;
         }
     }
     //새로운 객체를 찾아야 하는 경우 -> 유닛의 상태가 idle이 되었을 때(이동을 완료했을 때, 공격하던 객체가 죽었을 때, 공격하던 객체가 어그로 범위를 벗어났을 때)
     public override void DestroyEntity()
     {
         gameObject.GetComponent<PhotonView>().RPC("SyncSetTag", RpcTarget.AllBuffered, "Untagged");
-        gameObject.GetComponent<PhotonView>().RPC("SetState", RpcTarget.AllBuffered, "Die");
+        gameObject.GetComponent<PhotonView>().RPC("ChangeState", RpcTarget.AllBuffered, "Die");
         GameStatus.instance.currentUnitCount -= population;
         animator.SetTrigger("isDead");
     }

--- a/Assets/Scripts/Unit/UnitController.cs
+++ b/Assets/Scripts/Unit/UnitController.cs
@@ -212,6 +212,8 @@ public class UnitController : MonoBehaviour
                 break;
             }
 
+            Debug.Log($"------------------enemy name: {enemy.name}");
+            Debug.Log($"------------------ally name: {ally.name}");
             Vector3 rot = (enemy.transform.position - ally.transform.position).normalized;
             ally.transform.rotation = Quaternion.LookRotation(rot);
             yield return null;

--- a/Assets/Scripts/Unit/Units/Archer.cs
+++ b/Assets/Scripts/Unit/Units/Archer.cs
@@ -48,12 +48,6 @@ public class Archer : Unit
         this.fow = 20;
     }
 
-    /*public void Shoot(){
-        if(gameObject.GetComponent<PhotonView>().IsMine){
-            gameObject.GetComponent<PhotonView>().RPC("Shoot2", RpcTarget.All, target.GetComponent<PhotonView>().ViewID);
-        }
-    }*/
-
     public void Shoot(){
         //PhotonView targetView = PhotonView.Find(viewID);
         if(target != null){

--- a/Assets/Scripts/Unit/Units/Arrow.cs
+++ b/Assets/Scripts/Unit/Units/Arrow.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 
 public class Arrow : MonoBehaviour
 {
-    private GameObject _tartget;
+    private GameObject _target;
     private Unit _unit;
     private Coroutine coroutine;
     private UnityEngine.Vector3 initPos;
@@ -22,14 +22,16 @@ public class Arrow : MonoBehaviour
     }
 
     private void OnTriggerEnter(Collider other) {
-        if(other.gameObject == _tartget){
+        if(other.gameObject == _target){
             if(gameObject.transform.parent.gameObject.GetComponent<PhotonView>().IsMine == false){  //화살을 쏜 유닛이 자신의 유닛이 아닌 경우 return
                 StopCoroutine(coroutine);
                 gameObject.SetActive(false);
                 return;
             }
             else{
-                _tartget.GetComponent<PhotonView>().RPC("AttackRequest", RpcTarget.MasterClient, _unit.unitPower);  //화살을 쏜 유닛이 자신의 유닛인 경우 적에게 맞았을 때 마스터 클라이언트에게 판정을 요구
+                if(_target != null){
+                    _target.GetComponent<PhotonView>().RPC("AttackRequest", RpcTarget.MasterClient, _unit.unitPower);  //화살을 쏜 유닛이 자신의 유닛인 경우 적에게 맞았을 때 마스터 클라이언트에게 판정을 요구
+                }
                 StopCoroutine(coroutine);
                 gameObject.SetActive(false);
             }        
@@ -37,7 +39,7 @@ public class Arrow : MonoBehaviour
     }
 
     public void SetArrowTarget(GameObject target){
-        _tartget = target;
+        _target = target;
     }
 
     public void SetUnit(Unit unit){
@@ -45,20 +47,23 @@ public class Arrow : MonoBehaviour
     }
 
     private IEnumerator Launch(){
-        UnityEngine.Vector3 currentPos;
+        UnityEngine.Vector3 currentPos = UnityEngine.Vector3.zero;;
         UnityEngine.Vector3 targetPos;
         for(float time = 0f; time < 1f; time += Time.deltaTime){
-            currentPos = gameObject.transform.position;
-            targetPos = _tartget.transform.position + new UnityEngine.Vector3(0, 1.2f, 0);
-            float distance = UnityEngine.Vector3.Distance(currentPos, targetPos);
-            UnityEngine.Vector3 dir = (targetPos - currentPos).normalized;
-            transform.position += dir * distance * time/1f;
+            if(_target != null){
+                currentPos = gameObject.transform.position;
+                targetPos = _target.transform.position + new UnityEngine.Vector3(0, 1.2f, 0);
+                float distance = UnityEngine.Vector3.Distance(currentPos, targetPos);
+                UnityEngine.Vector3 dir = (targetPos - currentPos).normalized;
+                transform.position += dir * distance * time/1f;
 
-            yield return null;
+                yield return null;
+            }
         }
 
-        _tartget.GetComponent<PhotonView>().RPC("AttackRequest", RpcTarget.MasterClient, _unit.unitPower);
-        StopCoroutine(coroutine);
+        if(_target != null){
+            _target.GetComponent<PhotonView>().RPC("AttackRequest", RpcTarget.MasterClient, _unit.unitPower);
+        }
         gameObject.SetActive(false);
     }
 


### PR DESCRIPTION
유닛이 죽는 상황에서도 범위 내에 적이 들어오면 코루틴을 실행하는 오류가 있어서 각 코루틴을 실행하는 함수에 유닛의 상태가 die라면 코루틴을 실행하지 않고 return 하도록 변경