### PR TITLE
[update] 투사체의 target과 유닛의 target을 다르게 설정

### DIFF
--- a/Assets/Scripts/Unit/Unit.cs
+++ b/Assets/Scripts/Unit/Unit.cs
@@ -49,6 +49,7 @@ public abstract class Unit : Entity
     private Quaternion _initRotation;
     public State state = State.Idle;
     public GameObject target;
+    public GameObject projectileTarget;
 
     [HideInInspector] public Animator animator;
     private new Rigidbody rigidbody;
@@ -416,7 +417,7 @@ public abstract class Unit : Entity
     [PunRPC]
     public void SetTarget(int viewID)
     {
-        target = PhotonView.Find(viewID).gameObject;
+        projectileTarget = PhotonView.Find(viewID).gameObject;
     }
 
     public void Launch()
@@ -426,7 +427,7 @@ public abstract class Unit : Entity
             GameObject pjtObject = Instantiate(prefab, prefabPosition.position, Quaternion.identity);
             pjtObject.AddComponent<Projectile>();
             pjtObject.TryGetComponent(out Projectile projectile);
-            projectile.SetArrowTarget(target);
+            projectile.SetArrowTarget(projectileTarget);
             projectile.SetUnit(this);
             projectile.LaunchProjectile();
         }


### PR DESCRIPTION
투사체의 target과 유닛의 target이 같은 경우에 attackunit 함수에서 점사를 할 지정 타겟이 있다고 판단하여 return을 하는 오류가 발생해서 따로 변수를 만듬