### PR TITLE
[Fix] 땅 클릭하면 가끔 클릭 풀리던 버그 수정

### DIFF
--- a/Assets/Resources/Prefabs/Buildings/BlueTeamBuildings/Academy.prefab
+++ b/Assets/Resources/Prefabs/Buildings/BlueTeamBuildings/Academy.prefab
@@ -162,8 +162,8 @@ MonoBehaviour:
       m_Calls: []
   teamID: 
   healthBar: {fileID: 2095580103585111435}
-  clickedEffect: {fileID: 0}
-  enemyClickedEffect: {fileID: 0}
+  clickedEffect: {fileID: 9164422651050974416}
+  enemyClickedEffect: {fileID: 2647235613257668713}
   progressBar: {fileID: 7783155889680450107}
   state: 0
   inProgressItem: 0
@@ -556,6 +556,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 2218383157601778266, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
   m_PrefabInstance: {fileID: 4212441774807374379}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &2647235613257668713 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2218383157602042434, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
+  m_PrefabInstance: {fileID: 4212441774807374379}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5321997382128771994
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -636,6 +641,11 @@ PrefabInstance:
 --- !u!4 &12412014299615347 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5329887860975645673, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
+  m_PrefabInstance: {fileID: 5321997382128771994}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &9164422651050974416 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3960099710613061450, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
   m_PrefabInstance: {fileID: 5321997382128771994}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5488389638942723936

--- a/Assets/Resources/Prefabs/Buildings/BlueTeamBuildings/Barrack.prefab
+++ b/Assets/Resources/Prefabs/Buildings/BlueTeamBuildings/Barrack.prefab
@@ -216,8 +216,8 @@ MonoBehaviour:
       m_Calls: []
   teamID: 
   healthBar: {fileID: 2579093876378188609}
-  clickedEffect: {fileID: 0}
-  enemyClickedEffect: {fileID: 0}
+  clickedEffect: {fileID: 7454256941416888365}
+  enemyClickedEffect: {fileID: 2084592378773553540}
   progressBar: {fileID: 5971038891646231793}
   state: 0
   inProgressItem: 0
@@ -344,6 +344,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
+--- !u!1 &2084592378773553540 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2218383157602042434, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
+  m_PrefabInstance: {fileID: 154444014179615686}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &2084592378773813660 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2218383157601778266, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
@@ -830,6 +835,11 @@ PrefabInstance:
 --- !u!4 &1761011085043692686 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5329887860975645673, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
+  m_PrefabInstance: {fileID: 5874891310352254823}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &7454256941416888365 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3960099710613061450, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
   m_PrefabInstance: {fileID: 5874891310352254823}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8311221983301997772

--- a/Assets/Resources/Prefabs/Buildings/BlueTeamBuildings/Command.prefab
+++ b/Assets/Resources/Prefabs/Buildings/BlueTeamBuildings/Command.prefab
@@ -663,8 +663,8 @@ MonoBehaviour:
       m_Calls: []
   teamID: 
   healthBar: {fileID: 124938074411608227}
-  clickedEffect: {fileID: 0}
-  enemyClickedEffect: {fileID: 0}
+  clickedEffect: {fileID: 5276870353205315310}
+  enemyClickedEffect: {fileID: 1079845057815734832}
   progressBar: {fileID: 6941047166868218723}
   state: 0
   inProgressItem: 0
@@ -1265,6 +1265,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
+--- !u!1 &1079845057815734832 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2218383157602042434, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
+  m_PrefabInstance: {fileID: 1167882429118359666}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1079845057815974440 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2218383157601778266, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
@@ -2443,5 +2448,10 @@ PrefabInstance:
 --- !u!4 &3907361757969943117 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5329887860975645673, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
+  m_PrefabInstance: {fileID: 9209346754017769892}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &5276870353205315310 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3960099710613061450, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
   m_PrefabInstance: {fileID: 9209346754017769892}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Resources/Prefabs/Buildings/BlueTeamBuildings/Defender.prefab
+++ b/Assets/Resources/Prefabs/Buildings/BlueTeamBuildings/Defender.prefab
@@ -197,8 +197,8 @@ MonoBehaviour:
       m_Calls: []
   teamID: 
   healthBar: {fileID: 6776851228889223069}
-  clickedEffect: {fileID: 0}
-  enemyClickedEffect: {fileID: 0}
+  clickedEffect: {fileID: 561048515734014310}
+  enemyClickedEffect: {fileID: 1612117697407877406}
   progressBar: {fileID: 2773442191404222815}
   state: 0
   inProgressItem: 0
@@ -1262,6 +1262,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 2218383157601778266, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
   m_PrefabInstance: {fileID: 618720736571966300}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1612117697407877406 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2218383157602042434, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
+  m_PrefabInstance: {fileID: 618720736571966300}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1207521181079583238
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1481,6 +1486,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
+--- !u!1 &561048515734014310 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3960099710613061450, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
+  m_PrefabInstance: {fileID: 3547753571235788332}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &8704252837833426373 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5329887860975645673, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}

--- a/Assets/Resources/Prefabs/Buildings/BlueTeamBuildings/PopulationBuilding.prefab
+++ b/Assets/Resources/Prefabs/Buildings/BlueTeamBuildings/PopulationBuilding.prefab
@@ -816,8 +816,8 @@ MonoBehaviour:
       m_Calls: []
   teamID: 
   healthBar: {fileID: 87844144323508321}
-  clickedEffect: {fileID: 0}
-  enemyClickedEffect: {fileID: 0}
+  clickedEffect: {fileID: 4356350300114935447}
+  enemyClickedEffect: {fileID: 5660664272720987173}
   progressBar: {fileID: 4600271945962562612}
   state: 0
   inProgressItem: 0
@@ -1148,6 +1148,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
+--- !u!1 &4356350300114935447 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3960099710613061450, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
+  m_PrefabInstance: {fileID: 757101926397747677}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &4861166261514342964 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5329887860975645673, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
@@ -1352,6 +1357,11 @@ PrefabInstance:
 --- !u!4 &5660664272720755773 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2218383157601778266, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
+  m_PrefabInstance: {fileID: 5784873241744229991}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &5660664272720987173 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2218383157602042434, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
   m_PrefabInstance: {fileID: 5784873241744229991}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6363616829865637387

--- a/Assets/Resources/Prefabs/Buildings/BlueTeamBuildings/ResourceBuilding.prefab
+++ b/Assets/Resources/Prefabs/Buildings/BlueTeamBuildings/ResourceBuilding.prefab
@@ -838,8 +838,8 @@ MonoBehaviour:
       m_Calls: []
   teamID: 
   healthBar: {fileID: 778075159778669433}
-  clickedEffect: {fileID: 0}
-  enemyClickedEffect: {fileID: 0}
+  clickedEffect: {fileID: 3716060624250993051}
+  enemyClickedEffect: {fileID: 3343330570294776325}
   progressBar: {fileID: 1765992660971764573}
   state: 0
   inProgressItem: 0
@@ -1148,6 +1148,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
+--- !u!1 &3716060624250993051 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3960099710613061450, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
+  m_PrefabInstance: {fileID: 389280749879822033}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &5517067885155104056 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5329887860975645673, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
@@ -1336,6 +1341,11 @@ PrefabInstance:
 --- !u!4 &3343330570294503965 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2218383157601778266, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
+  m_PrefabInstance: {fileID: 3507357201864560711}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &3343330570294776325 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2218383157602042434, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
   m_PrefabInstance: {fileID: 3507357201864560711}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6386386104736319804

--- a/Assets/Resources/Prefabs/Buildings/RedTeamBuildings/Academy.prefab
+++ b/Assets/Resources/Prefabs/Buildings/RedTeamBuildings/Academy.prefab
@@ -195,8 +195,8 @@ MonoBehaviour:
       m_Calls: []
   teamID: 
   healthBar: {fileID: 2778639669708780052}
-  clickedEffect: {fileID: 0}
-  enemyClickedEffect: {fileID: 0}
+  clickedEffect: {fileID: 6706322133796091724}
+  enemyClickedEffect: {fileID: 5247785661392619011}
   progressBar: {fileID: 6311823490508484004}
   state: 0
   inProgressItem: 0
@@ -745,6 +745,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
+--- !u!1 &5247785661392619011 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2218383157602042434, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
+  m_PrefabInstance: {fileID: 6204455034565313601}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &5247785661392911899 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2218383157601778266, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
@@ -830,6 +835,11 @@ PrefabInstance:
 --- !u!4 &2455355713802222575 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5329887860975645673, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
+  m_PrefabInstance: {fileID: 7774547516870526982}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &6706322133796091724 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3960099710613061450, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
   m_PrefabInstance: {fileID: 7774547516870526982}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8245424992888857283

--- a/Assets/Resources/Prefabs/Buildings/RedTeamBuildings/Barrack.prefab
+++ b/Assets/Resources/Prefabs/Buildings/RedTeamBuildings/Barrack.prefab
@@ -195,8 +195,8 @@ MonoBehaviour:
       m_Calls: []
   teamID: 
   healthBar: {fileID: 2579093876378188609}
-  clickedEffect: {fileID: 0}
-  enemyClickedEffect: {fileID: 0}
+  clickedEffect: {fileID: 4372409055882967551}
+  enemyClickedEffect: {fileID: 2636305227638179209}
   progressBar: {fileID: 5971038891646231793}
   state: 0
   inProgressItem: 0
@@ -1148,6 +1148,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
+--- !u!1 &4372409055882967551 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3960099710613061450, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
+  m_PrefabInstance: {fileID: 745613376040535733}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &4877226524814849372 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5329887860975645673, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
@@ -1563,6 +1568,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
+--- !u!1 &2636305227638179209 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2218383157602042434, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
+  m_PrefabInstance: {fileID: 4206166448155215819}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &2636305227638472081 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2218383157601778266, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}

--- a/Assets/Resources/Prefabs/Buildings/RedTeamBuildings/Command.prefab
+++ b/Assets/Resources/Prefabs/Buildings/RedTeamBuildings/Command.prefab
@@ -663,8 +663,8 @@ MonoBehaviour:
       m_Calls: []
   teamID: 
   healthBar: {fileID: 124938074411608227}
-  clickedEffect: {fileID: 0}
-  enemyClickedEffect: {fileID: 0}
+  clickedEffect: {fileID: 5276870353205315310}
+  enemyClickedEffect: {fileID: 1079845057815734832}
   progressBar: {fileID: 6941047166868218723}
   state: 0
   inProgressItem: 0
@@ -1273,6 +1273,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
+--- !u!1 &1079845057815734832 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2218383157602042434, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
+  m_PrefabInstance: {fileID: 1167882429118359666}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1079845057815974440 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2218383157601778266, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
@@ -2511,5 +2516,10 @@ PrefabInstance:
 --- !u!4 &3907361757969943117 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5329887860975645673, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
+  m_PrefabInstance: {fileID: 9209346754017769892}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &5276870353205315310 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3960099710613061450, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
   m_PrefabInstance: {fileID: 9209346754017769892}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Resources/Prefabs/Buildings/RedTeamBuildings/Defender.prefab
+++ b/Assets/Resources/Prefabs/Buildings/RedTeamBuildings/Defender.prefab
@@ -197,8 +197,8 @@ MonoBehaviour:
       m_Calls: []
   teamID: 
   healthBar: {fileID: 6776851228889223069}
-  clickedEffect: {fileID: 0}
-  enemyClickedEffect: {fileID: 0}
+  clickedEffect: {fileID: 561048515734014310}
+  enemyClickedEffect: {fileID: 1612117697407877406}
   progressBar: {fileID: 2773442191404222815}
   state: 0
   inProgressItem: 0
@@ -1262,6 +1262,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 2218383157601778266, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
   m_PrefabInstance: {fileID: 618720736571966300}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1612117697407877406 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2218383157602042434, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
+  m_PrefabInstance: {fileID: 618720736571966300}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1207521181079583238
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1493,6 +1498,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
+--- !u!1 &561048515734014310 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3960099710613061450, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
+  m_PrefabInstance: {fileID: 3547753571235788332}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &8704252837833426373 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5329887860975645673, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}

--- a/Assets/Resources/Prefabs/Buildings/RedTeamBuildings/PopulationBuilding.prefab
+++ b/Assets/Resources/Prefabs/Buildings/RedTeamBuildings/PopulationBuilding.prefab
@@ -768,8 +768,8 @@ MonoBehaviour:
       m_Calls: []
   teamID: 
   healthBar: {fileID: 87844144323508321}
-  clickedEffect: {fileID: 0}
-  enemyClickedEffect: {fileID: 0}
+  clickedEffect: {fileID: 3828114676838795346}
+  enemyClickedEffect: {fileID: 6723149209401745936}
   progressBar: {fileID: 4600271945962562612}
   state: 0
   inProgressItem: 0
@@ -1215,6 +1215,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
+--- !u!1 &3828114676838795346 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3960099710613061450, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
+  m_PrefabInstance: {fileID: 276174990260860696}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &5342038223365784817 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5329887860975645673, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
@@ -1609,5 +1614,10 @@ PrefabInstance:
 --- !u!4 &6723149209401465352 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2218383157601778266, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
+  m_PrefabInstance: {fileID: 4865060981463752786}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &6723149209401745936 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2218383157602042434, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
   m_PrefabInstance: {fileID: 4865060981463752786}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Resources/Prefabs/Buildings/RedTeamBuildings/ResourceBuilding.prefab
+++ b/Assets/Resources/Prefabs/Buildings/RedTeamBuildings/ResourceBuilding.prefab
@@ -838,8 +838,8 @@ MonoBehaviour:
       m_Calls: []
   teamID: 
   healthBar: {fileID: 778075159778669433}
-  clickedEffect: {fileID: 0}
-  enemyClickedEffect: {fileID: 0}
+  clickedEffect: {fileID: 830851169362017178}
+  enemyClickedEffect: {fileID: 6989499750040840269}
   progressBar: {fileID: 1765992660971764573}
   state: 0
   inProgressItem: 0
@@ -1215,6 +1215,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
+--- !u!1 &830851169362017178 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3960099710613061450, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
+  m_PrefabInstance: {fileID: 4427846609199269072}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &8396204823315429177 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5329887860975645673, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
@@ -1597,5 +1602,10 @@ PrefabInstance:
 --- !u!4 &6989499750040588373 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2218383157601778266, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
+  m_PrefabInstance: {fileID: 9094728385766746639}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &6989499750040840269 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2218383157602042434, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
   m_PrefabInstance: {fileID: 9094728385766746639}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Resources/Prefabs/Units/BlueTeamUnits/Archer.prefab
+++ b/Assets/Resources/Prefabs/Units/BlueTeamUnits/Archer.prefab
@@ -13542,11 +13542,12 @@ MonoBehaviour:
       m_Calls: []
   teamID: 
   healthBar: {fileID: 4508799639484592511}
-  clickedEffect: {fileID: 0}
-  enemyClickedEffect: {fileID: 0}
+  clickedEffect: {fileID: 1952465889417981387}
+  enemyClickedEffect: {fileID: 4579879912284372077}
   isTurretUnit: 0
   state: 0
   target: {fileID: 0}
+  projectileTarget: {fileID: 0}
   animator: {fileID: 0}
   prefab: {fileID: 4311876242911358135, guid: d97eea1caf42246ecb495b467d014615, type: 3}
   prefabPosition: {fileID: 5862943357473166780}
@@ -20262,6 +20263,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
+--- !u!1 &4579879912284372077 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2218383157602042434, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
+  m_PrefabInstance: {fileID: 2397682164465172015}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &4579879912284636277 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2218383157601778266, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
@@ -20344,6 +20350,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
+--- !u!1 &1952465889417981387 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3960099710613061450, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
+  m_PrefabInstance: {fileID: 3309464944556413569}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &7213082221949362536 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5329887860975645673, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}

--- a/Assets/Resources/Prefabs/Units/BlueTeamUnits/Healer.prefab
+++ b/Assets/Resources/Prefabs/Units/BlueTeamUnits/Healer.prefab
@@ -6400,11 +6400,12 @@ MonoBehaviour:
       m_Calls: []
   teamID: 
   healthBar: {fileID: 6922770217836032722}
-  clickedEffect: {fileID: 0}
-  enemyClickedEffect: {fileID: 0}
+  clickedEffect: {fileID: 5871974877446687666}
+  enemyClickedEffect: {fileID: 7734174381063801536}
   isTurretUnit: 0
   state: 0
   target: {fileID: 0}
+  projectileTarget: {fileID: 0}
   animator: {fileID: 0}
   prefab: {fileID: 0}
   prefabPosition: {fileID: 0}
@@ -20259,6 +20260,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5329887860975645673, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
   m_PrefabInstance: {fileID: 7460331249514427640}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &5871974877446687666 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3960099710613061450, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
+  m_PrefabInstance: {fileID: 7460331249514427640}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8474658654172760194
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -20339,5 +20345,10 @@ PrefabInstance:
 --- !u!4 &7734174381063566040 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2218383157601778266, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
+  m_PrefabInstance: {fileID: 8474658654172760194}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &7734174381063801536 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2218383157602042434, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
   m_PrefabInstance: {fileID: 8474658654172760194}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Resources/Prefabs/Units/BlueTeamUnits/Scout.prefab
+++ b/Assets/Resources/Prefabs/Units/BlueTeamUnits/Scout.prefab
@@ -10232,6 +10232,7 @@ MonoBehaviour:
   isTurretUnit: 0
   state: 0
   target: {fileID: 0}
+  projectileTarget: {fileID: 0}
   animator: {fileID: 0}
   prefab: {fileID: 0}
   prefabPosition: {fileID: 0}

--- a/Assets/Resources/Prefabs/Units/BlueTeamUnits/Soldier.prefab
+++ b/Assets/Resources/Prefabs/Units/BlueTeamUnits/Soldier.prefab
@@ -3134,8 +3134,8 @@ MonoBehaviour:
       m_Calls: []
   teamID: 
   healthBar: {fileID: 6212170728899033757}
-  clickedEffect: {fileID: 0}
-  enemyClickedEffect: {fileID: 0}
+  clickedEffect: {fileID: 5004287419509689969}
+  enemyClickedEffect: {fileID: 4543562318480356146}
   isTurretUnit: 0
   state: 0
   target: {fileID: 0}
@@ -20097,6 +20097,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 2218383157601778266, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
   m_PrefabInstance: {fileID: 2433279024173904240}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &4543562318480356146 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2218383157602042434, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
+  m_PrefabInstance: {fileID: 2433279024173904240}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8107242913595357803
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -20239,5 +20244,10 @@ PrefabInstance:
 --- !u!4 &4210942158414119634 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5329887860975645673, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
+  m_PrefabInstance: {fileID: 8324856977534693691}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &5004287419509689969 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3960099710613061450, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
   m_PrefabInstance: {fileID: 8324856977534693691}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Resources/Prefabs/Units/BlueTeamUnits/Soldier.prefab
+++ b/Assets/Resources/Prefabs/Units/BlueTeamUnits/Soldier.prefab
@@ -3139,6 +3139,7 @@ MonoBehaviour:
   isTurretUnit: 0
   state: 0
   target: {fileID: 0}
+  projectileTarget: {fileID: 0}
   animator: {fileID: 0}
   prefab: {fileID: 0}
   prefabPosition: {fileID: 0}

--- a/Assets/Resources/Prefabs/Units/BlueTeamUnits/Tanker.prefab
+++ b/Assets/Resources/Prefabs/Units/BlueTeamUnits/Tanker.prefab
@@ -13716,11 +13716,12 @@ MonoBehaviour:
       m_Calls: []
   teamID: 
   healthBar: {fileID: 1300174168617867986}
-  clickedEffect: {fileID: 0}
-  enemyClickedEffect: {fileID: 0}
+  clickedEffect: {fileID: 8459847345101621846}
+  enemyClickedEffect: {fileID: 7512794346983485780}
   isTurretUnit: 0
   state: 0
   target: {fileID: 0}
+  projectileTarget: {fileID: 0}
   animator: {fileID: 0}
   prefab: {fileID: 0}
   prefabPosition: {fileID: 0}
@@ -20174,6 +20175,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5329887860975645673, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
   m_PrefabInstance: {fileID: 4869081562125677852}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &8459847345101621846 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3960099710613061450, guid: 41e54c08d472d3e45ab057f7ac511002, type: 3}
+  m_PrefabInstance: {fileID: 4869081562125677852}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8542071875987518230
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -20235,6 +20241,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
+--- !u!1 &7512794346983485780 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2218383157602042434, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}
+  m_PrefabInstance: {fileID: 8542071875987518230}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &7512794346983721292 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2218383157601778266, guid: 193b64beca1aa4be98b1458b103ef51d, type: 3}

--- a/Assets/Resources/Prefabs/Units/RedTeamUnits/Soldier.prefab
+++ b/Assets/Resources/Prefabs/Units/RedTeamUnits/Soldier.prefab
@@ -84,6 +84,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &3742256514944475680 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5004287419509689969, guid: b3c52779e94764e83bc8fdbef740ece5, type: 3}
+  m_PrefabInstance: {fileID: 8547241234072923217}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &5300771150843076451 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4543562318480356146, guid: b3c52779e94764e83bc8fdbef740ece5, type: 3}
+  m_PrefabInstance: {fileID: 8547241234072923217}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &5864727300351772452 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2881834226238106485, guid: b3c52779e94764e83bc8fdbef740ece5, type: 3}
@@ -115,8 +125,8 @@ MonoBehaviour:
       m_Calls: []
   teamID: red
   healthBar: {fileID: 2354246537718519500}
-  clickedEffect: {fileID: 0}
-  enemyClickedEffect: {fileID: 0}
+  clickedEffect: {fileID: 3742256514944475680}
+  enemyClickedEffect: {fileID: 5300771150843076451}
   isTurretUnit: 0
   state: 0
   target: {fileID: 0}

--- a/Assets/Resources/Prefabs/Units/RedTeamUnits/Soldier.prefab
+++ b/Assets/Resources/Prefabs/Units/RedTeamUnits/Soldier.prefab
@@ -120,6 +120,7 @@ MonoBehaviour:
   isTurretUnit: 0
   state: 0
   target: {fileID: 0}
+  projectileTarget: {fileID: 0}
   animator: {fileID: 0}
   prefab: {fileID: 0}
   prefabPosition: {fileID: 0}

--- a/Assets/Scripts/Click/ClickManager.cs
+++ b/Assets/Scripts/Click/ClickManager.cs
@@ -159,8 +159,8 @@ public class ClickManager : MonoBehaviour
         {
             RaycastHit hit = hits[i];
             GameObject hitObject = hit.collider.gameObject;
-             bool isTarget = GameStatus.instance.gameState == GameStates.ConstructionMode
-                        ? hitObject.layer == LayerMask.NameToLayer("Grid")
+            bool isTarget = GameStatus.instance.gameState == GameStates.ConstructionMode
+                        ? hitObject.layer == LayerMask.NameToLayer("Grid") && hitObject.tag != "HasObject"
                         : hitObject.CompareTag("Clickable");
             
             if(isTarget){

--- a/Assets/Scripts/Grid/GridEvent.cs
+++ b/Assets/Scripts/Grid/GridEvent.cs
@@ -98,23 +98,21 @@ public class GridEvent : MonoBehaviour
         switch(state)
         {
             case State.Default:
-                gameObject.tag = "Clickable";
                 gameObject.tag = "Untagged";
                 gridState = State.Default;
                 break;
             case State.Hovered:
-                gameObject.tag = "Clickable";
                 gridState = State.Hovered;
                 break;
             case State.Selected:
                 gridState = State.Selected;
                 break;  
             case State.HasObject:
-                gameObject.tag = "Untagged";
+                gameObject.tag = "HasObject";
                 gridState = State.HasObject;
                 break;
             case State.Builted:
-                gameObject.tag = "Untagged";
+                gameObject.tag = "HasObject";
                 gridState = State.Builted;
                 break;
         }

--- a/Assets/Scripts/Unit/Units/TurretArcher.cs
+++ b/Assets/Scripts/Unit/Units/TurretArcher.cs
@@ -16,8 +16,8 @@ public class TurretArcher : Unit
                 unitMaxHealth: 1000000,
                 unitCurrentHealth: 1000000,
                 unitCost: 0,
-                unitPower: 35,
-                unitPowerRange: 14,
+                unitPower: 10,
+                unitPowerRange: 15,
                 unitMoveSpeed: 3,
                 populationCost: 1)
     {
@@ -28,7 +28,7 @@ public class TurretArcher : Unit
     {
         this.maxHealth = 1000000;
         this.currentHealth = 1000000;
-        this.unitPower = 35;
+        this.unitPower = 15;
         if(GameStatus.instance.teamID == teamID){
             SetAttEnter((GameObject enemy) => { GameManager.instance.AttackUnit(gameObject, enemy); });
             SetAttExit((GameObject enemy) => { attackList.Remove(enemy); });
@@ -42,7 +42,7 @@ public class TurretArcher : Unit
         this.unitType = "Archer";
         this.unitLocation = unitLocation;
         this.unitCost = 40;
-        this.unitPowerRange = 14;
+        this.unitPowerRange = 15;
         this.unitMoveSpeed = 5;
         this.populationCost = 1;
         this.population = 1;

--- a/Assets/Scripts/Unit/Units/TurretMagician.cs
+++ b/Assets/Scripts/Unit/Units/TurretMagician.cs
@@ -17,7 +17,7 @@ public class TurretMagician : Unit
                 unitCurrentHealth: 1000000,
                 unitCost: 0,
                 unitPower: 35,
-                unitPowerRange: 14,
+                unitPowerRange: 20,
                 unitMoveSpeed: 3,
                 populationCost: 1)
     {

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -13,6 +13,7 @@ TagManager:
   - InProgress
   - BarrackUI
   - Projectile
+  - HasObject
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
Grid State변화하면서 Default되면 Tag를 Clickable로 바꾸는 코드가 있었어서 한번 grid가 켜진애는 클릭이 먹는 현상 때문에 클릭이 풀렸었음 State바꿀때 Default일때는 Untagged로 바꾸고, 위에 뭐가 있거나 건물이 있으면 tag를 HasObject로 바꿔서 ClickManager에서 GameState가 Construction Mode 일때 Layer가 Grid && != HasObject일때만 클릭 콜백함수 실행되도록 변경