### PR TITLE
[Fix] ReloadBuildingUI 로직수정

### DIFF
--- a/Assets/Scripts/InGame/GameManager.cs
+++ b/Assets/Scripts/InGame/GameManager.cs
@@ -455,13 +455,13 @@ public class GameManager : MonoBehaviour
 
         if (building.GetComponent<Academy>()) // 다른 건물에서 업그래드이가 완료됐을 때 아카데미를 클릭하고 있으면 UI를 업데이트 해야줘야기 때문에 필터링해줌
         {
-            if (clickedObject[0].GetComponent<Academy>())
+            if (clickedObject[0].GetComponent<Academy>() && clickedObject.Count == 1)
             {
                 SetBuildingInfo(9, building);
             }
         }
 
-        if (clickedObject[0].name == building.name)
+        if (clickedObject[0].name == building.name && clickedObject.Count == 1)
         {
             switch (building.type)
             {


### PR DESCRIPTION
ReloadBuildingUI에서 리스트 업데이트하는 조건이 ClickObject[0]이 진행이 완료된 건물이면 UI를 해당 건물 UI로 바꾸게 했는데 건물포함해서 드래그했을 때 보이는 UI는 유닛, 유닛그룹 UI인데 ClickedObejct[0]이 건물이라서 UI가 건물로 업데이트 되는 버그 발생 그래서 조건에 ClickedObject의 크기가 1인거를 추가해서 버그 해결